### PR TITLE
[Technical-Support] LPS-68216 

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/js/main.js
@@ -350,7 +350,7 @@ AUI.add(
 					);
 				},
 
-				buildDataTableColumns: function(columns, structure, editable) {
+				buildDataTableColumns: function(columns, locale, structure, editable) {
 					var instance = this;
 
 					columns.forEach(
@@ -517,7 +517,7 @@ AUI.add(
 								structureField = instance.findStructureFieldByAttribute(structure, 'name', name);
 
 								var multiple = A.DataType.Boolean.parse(structureField.multiple);
-								var options = instance.getCellEditorOptions(structureField.options);
+								var options = instance.getCellEditorOptions(structureField.options, locale);
 
 								item.formatter = function(obj) {
 									var data = obj.data;
@@ -601,12 +601,27 @@ AUI.add(
 					return structureField;
 				},
 
-				getCellEditorOptions: function(options) {
+				getCellEditorOptions: function(options, locale) {
 					var normalized = {};
 
 					options.forEach(
 						function(item, index) {
-							normalized[item.value] = item.label;
+							var localizationMap = item.localizationMap;
+							var isIncludeLocale;
+
+							for (var key in localizationMap) {
+								if (key === locale) {
+									normalized[item.value] = localizationMap[key].label;
+
+									isIncludeLocale = true;
+
+									break;
+								}
+							}
+
+							if (!isIncludeLocale) {
+								normalized[item.value] = item.label;
+							}
 						}
 					);
 

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_spreadsheet_records.jsp
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_spreadsheet_records.jsp
@@ -55,7 +55,7 @@ DDMStructure ddmStructure = recordSet.getDDMStructure();
 <aui:script use="liferay-portlet-dynamic-data-lists">
 	var structure = <%= DDMUtil.getDDMFormFieldsJSONArray(ddmStructure, ddmStructure.getDefinition()) %>;
 
-	var columns = Liferay.SpreadSheet.buildDataTableColumns(<%= ddlDisplayContext.getRecordSetJSONArray(recordSet, locale) %>, structure, <%= editable %>);
+	var columns = Liferay.SpreadSheet.buildDataTableColumns(<%= ddlDisplayContext.getRecordSetJSONArray(recordSet, locale) %>, '<%= LocaleUtil.toLanguageId(locale) %>', structure, <%= editable %>);
 
 	var ignoreEmptyRecordsNumericSort = function(recA, recB, desc, field) {
 		var a = recA.get(field);


### PR DESCRIPTION
cc @daledotshan,

Hi John,

The root issue is we still use structure's defaultLocale value regarding option label.

We should firstly check whether current locale exists in structureField.options's localizationMap, if yes, use right locale matched value in localizationMap. Please refer to the below example, when current locale is ja_JP, it will display label related value. Expect behavior is that it should display "JAoption 1".
```
"options":[{"name":"SelectcokaJq7SnwDW","id":"SelectcokaJq7SnwDW","label":"option 1","type":"option","localizationMap":{"en_US":{"label":"option 1"},"ja_JP":{"label":"JAoption 1"}},"value":"value 1"},{"name":"SelectcokaNoOlFxdJ","id":"SelectcokaNoOlFxdJ","label":"option 2","type":"option","localizationMap":{"en_US":{"label":"option 2"},"ja_JP":{"label":"JAoption 2"}},"value":"value 2"},{"name":"SelectcokaHmz9bl0J","id":"SelectcokaHmz9bl0J","label":"option 3","type":"option","localizationMap":{"en_US":{"label":"option 3"},"ja_JP":{"label":"JAoption 3"}},"value":"value 3"}]
```

Regards,
Hai